### PR TITLE
跟新工作流配置

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -4,6 +4,7 @@
 name: Node.js Package
 
 on:
+  workflow_dispatch:
   release:
     types: [created]
   push:
@@ -42,11 +43,8 @@ jobs:
           node-version: 20
           registry-url: https://npm.pkg.github.com/
           cache: 'pnpm'
-      # 显式启用并激活 pnpm（Corepack）
-      - name: Enable Corepack and activate pnpm
-        run: |
-          corepack enable
-          corepack prepare pnpm@10.12.3 --activate
+      - name: Install pnpm globally
+        run: npm i -g pnpm@10.12.3
       - run: pnpm --version
       - run: pnpm install --frozen-lockfile
       - run: pnpm publish

--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -20,9 +20,12 @@ jobs:
         with:
           node-version: 20
           cache: 'pnpm'
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.12.3
+      # 显式启用并激活 pnpm（Corepack）
+      - name: Enable Corepack and activate pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.12.3 --activate
+      - run: pnpm --version
       - run: pnpm install --frozen-lockfile
       # - run: pnpm test
 
@@ -39,9 +42,12 @@ jobs:
           node-version: 20
           registry-url: https://npm.pkg.github.com/
           cache: 'pnpm'
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.12.3
+      # 显式启用并激活 pnpm（Corepack）
+      - name: Enable Corepack and activate pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.12.3 --activate
+      - run: pnpm --version
       - run: pnpm install --frozen-lockfile
       - run: pnpm publish
         env:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for publishing Node.js packages, focusing on improvements to how `pnpm` is set up and enabling manual workflow runs. The main changes streamline the installation of `pnpm` and add support for triggering the workflow manually.

**Workflow enhancements:**

* Added `workflow_dispatch` to the workflow triggers, allowing manual execution of the workflow.

**pnpm setup improvements:**

* Replaced the `pnpm/action-setup` GitHub Action with explicit activation of `pnpm` using Corepack for the install job, improving reliability and clarity of the setup process.
* Changed the publish job to install `pnpm` globally via `npm i -g pnpm@10.12.3` instead of using the `pnpm/action-setup` GitHub Action.